### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/proxy_pac_rb/encoding.rb
+++ b/lib/proxy_pac_rb/encoding.rb
@@ -7,21 +7,21 @@ module ProxyPacRb
         # workaround for jruby bug http://jira.codehaus.org/browse/JRUBY-6588
         # workaround for rbx bug https://github.com/rubinius/rubinius/issues/1729
         def encode(string)
-          if string.encoding.name == 'ASCII-8BIT'
+          if string.encoding == Encoding::BINARY
             data = string.dup
-            data.force_encoding('UTF-8')
+            data.force_encoding(Encoding::UTF_8)
 
             unless data.valid_encoding?
               raise ::Encoding::UndefinedConversionError, "Could not encode ASCII-8BIT data #{string.dump} as UTF-8"
             end
           else
-            data = string.encode('UTF-8')
+            data = string.encode(Encoding::UTF_8)
           end
           data
         end
       else
         def encode(string)
-          string.encode('UTF-8')
+          string.encode(Encoding::UTF_8)
         end
       end
     else


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576